### PR TITLE
Feature/connection gc

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,10 @@ stages:
     variables:
       compiler: clang9
       installCommand: |
+        brew uninstall openssl@1.0.2t
+        brew uninstall python@2.7.17
+        brew untap local/openssl
+        brew untap local/python2
         brew update
       CC: clang
       CXX: clang++

--- a/include/net/connection.h
+++ b/include/net/connection.h
@@ -131,19 +131,30 @@ namespace hyperion::net
                           std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback);
 
 
+        ///
+        /// Wrapper around asio::steady_timer::async_wait
+        /// \param callback Results forwarded to
+        void AsyncWait(std::function<void(const asio::error_code& error)>&& callback);
+
+
         [[nodiscard]] auto& GetStreambuf() noexcept {
             assert(refCount_ !=
                    0); // Reference count should not be zero as this should be accessed ONLY within asio callbacks
             return buf_;
         }
 
-
-        /// Use for timeouts
-        asio::steady_timer timer;
+        ///
+        /// Sets the expiry time of timer from now
+        auto SetTimerExpiresAfter(const asio::steady_timer::duration& expiry_time) {
+            return timer_.expires_after(expiry_time);
+        }
 
     private:
         SocketT socket_;
         asio::streambuf buf_{kReceiveBufSize};
+
+        /// Used for timeouts
+        asio::steady_timer timer_;
 
 
         // For tracking async operations

--- a/include/net/connection.h
+++ b/include/net/connection.h
@@ -91,9 +91,15 @@ namespace hyperion::net
 
 
         explicit Connection(SocketT&& socket);
+        ~Connection();
 
         Connection(const Connection& other)     = delete;
         Connection(Connection&& other) noexcept = delete;
+
+
+        ///
+        /// \return true if this is unreferenced by asio
+        [[nodiscard]] bool CanDestruct() const noexcept;
 
 
         ///
@@ -122,6 +128,19 @@ namespace hyperion::net
 
         /// Use for timeouts
         asio::steady_timer timer;
+
+    private:
+        // For tracking async operations
+
+        ///
+        /// Call prior to async operation
+        void IncRefCount() noexcept;
+
+        ///
+        /// Call after async operation completes
+        void DecRefCount() noexcept;
+
+        std::size_t refCount_ = 0;
     };
 
 } // namespace hyperion::net

--- a/include/net/connection.h
+++ b/include/net/connection.h
@@ -122,14 +122,24 @@ namespace hyperion::net
         void AsyncRead(std::size_t n,
                        std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback);
 
+        ///
+        /// Wrapper around asio::ip::tcp::socket::async_receive
+        /// \param n Bytes the buffer should hold
+        /// \param callback Results forwarded to
+        /// \remark callback must consume bytes_transferred from buf
+        void AsyncReceive(std::size_t n,
+                          std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback);
 
-        SocketT socket;
+
         asio::streambuf buf{kReceiveBufSize};
 
         /// Use for timeouts
         asio::steady_timer timer;
 
     private:
+        SocketT socket_;
+
+
         // For tracking async operations
 
         ///

--- a/include/net/connection.h
+++ b/include/net/connection.h
@@ -118,7 +118,7 @@ namespace hyperion::net
         /// Wrapper around asio::async_read
         /// \param n Bytes to read
         /// \param callback Results forwarded to
-        /// \remark callback must consume bytes_transferred from buf
+        /// \remark callback must call .consume with bytes_transferred on streambuf
         void AsyncRead(std::size_t n,
                        std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback);
 

--- a/include/net/connection.h
+++ b/include/net/connection.h
@@ -131,13 +131,19 @@ namespace hyperion::net
                           std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback);
 
 
-        asio::streambuf buf{kReceiveBufSize};
+        [[nodiscard]] auto& GetStreambuf() noexcept {
+            assert(refCount_ !=
+                   0); // Reference count should not be zero as this should be accessed ONLY within asio callbacks
+            return buf_;
+        }
+
 
         /// Use for timeouts
         asio::steady_timer timer;
 
     private:
         SocketT socket_;
+        asio::streambuf buf_{kReceiveBufSize};
 
 
         // For tracking async operations

--- a/include/net/net_data.h
+++ b/include/net/net_data.h
@@ -14,8 +14,12 @@
 
 namespace hyperion::net
 {
+    class ConnectionGc;
+
     class Connections
     {
+        friend ConnectionGc;
+
     public:
         decltype(auto) Add(Connection::SocketT&& socket) {
             connections_.push_back(std::make_unique<Connection>(std::move(socket)));

--- a/include/net/net_data.h
+++ b/include/net/net_data.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include <utility>
 
-#include "core/guarded_data.h"
 #include "media/media_config.h"
 #include "net/connection.h"
 #include "net/net_prop.h"
@@ -50,7 +49,7 @@ namespace hyperion::net
             return mediaConfig_;
         }
 
-        core::GuardedData<Connections> connections;
+        Connections connections;
 
         volatile bool servicesExit = false;
 

--- a/include/net/net_prop.h
+++ b/include/net/net_prop.h
@@ -28,6 +28,7 @@ namespace hyperion::net
         // Amount of time to wait before retrying
 
         std::chrono::milliseconds sleepAcceptorInitFailed{1000};
+        std::chrono::milliseconds sleepGcPass{20000};
     };
 
 } // namespace hyperion::net

--- a/include/net/service/connection_gc.h
+++ b/include/net/service/connection_gc.h
@@ -14,7 +14,7 @@ namespace hyperion::net
     ///
     /// Sweeps inactive connections
     ///
-    /// Befriends Connections access connections_
+    /// Must befriend Connections to access std::vector connections_
     class ConnectionGc
     {
     public:

--- a/include/net/service/connection_gc.h
+++ b/include/net/service/connection_gc.h
@@ -4,13 +4,42 @@
 #define HYPERION_INCLUDE_NET_SERVICE_CONNECTION_GC_H
 #pragma once
 
+#include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
+
 namespace hyperion::net
 {
     class NetData;
 
     ///
-    /// Removes old and no longer active connections
-    void ConnectionGCService(NetData& net_data);
+    /// Sweeps inactive connections
+    ///
+    /// Befriends Connections access connections_
+    class ConnectionGc
+    {
+    public:
+        ///
+        /// \param context Sweep timer attached to context, ensure lifetime outlasts this object
+        /// \param net_data Defines sweep times and connection to sweep, ensure lifetime outlasts this object
+        explicit ConnectionGc(asio::io_context& context, NetData& net_data) : netData_(net_data), timer_(context) {}
+
+        ///
+        /// Begins intermittent gc sweeps, stops when provided io_context stops
+        void Start();
+
+    private:
+        ///
+        /// Sets up async_wait for running Sweep after a set time
+        void SetupSweepTimer();
+
+        ///
+        /// Removes old and no longer active connections
+        static void Sweep(NetData& net_data);
+
+        NetData& netData_;
+        asio::steady_timer timer_;
+    };
+
 
 } // namespace hyperion::net
 

--- a/src/hyperion.cpp
+++ b/src/hyperion.cpp
@@ -12,6 +12,7 @@
 
 #include "net/net_data.h"
 #include "net/service/connection_acceptor.h"
+#include "net/service/connection_gc.h"
 #include "net/service/connection_listener.h"
 
 using namespace hyperion;
@@ -22,6 +23,9 @@ void RunConnectionServices(asio::io_context& io_context, net::NetData& net_data)
     auto conn_acceptor = MakeConnectionAcceptor(net_data, io_context);
     assert(conn_acceptor.has_value());
 
+    auto gc = net::ConnectionGc(io_context, net_data);
+
+
     conn_acceptor->onConnectionAccepted = [&net_data](net::Connection& conn) {
         conn.BeginOutFiles(net_data.GetMediaConfig().mediaSavePath);
         BeginAsyncReceive(conn);
@@ -29,6 +33,7 @@ void RunConnectionServices(asio::io_context& io_context, net::NetData& net_data)
 
     // Start services
     conn_acceptor->BeginAsyncAccept();
+    gc.Start();
 
     io_context.run();
 }

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -74,6 +74,14 @@ net::Connection::Connection(SocketT&& socket) : socket(std::move(socket)), timer
         info, "Created connection %llu, %s", id, this->socket.remote_endpoint().address().to_string().c_str());
 }
 
+net::Connection::~Connection() {
+    assert(CanDestruct());
+}
+
+bool net::Connection::CanDestruct() const noexcept {
+    return refCount_ == 0;
+}
+
 void net::Connection::End() noexcept {
     try {
         if (socket.is_open()) {
@@ -122,4 +130,13 @@ void net::Connection::AsyncRead(
 
             callback(error, bytes_transferred);
         });
+}
+
+void net::Connection::IncRefCount() noexcept {
+    refCount_++;
+}
+void net::Connection::DecRefCount() noexcept {
+    assert(refCount_ != 0);
+
+    refCount_--;
 }

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -126,7 +126,7 @@ void net::Connection::AsyncRead(
 
     async_read(
         socket_,
-        buf.prepare(n),
+        buf_.prepare(n),
         [this, callback{std::move(callback)}](const asio::error_code& error, const std::size_t bytes_transferred) {
             if (error) {
                 LOG_MESSAGE_F(debug, "Async read ec: %s", error.message().c_str());
@@ -146,7 +146,7 @@ void net::Connection::AsyncReceive(
     IncRefCount();
 
     socket_.async_receive(
-        buf.prepare(n),
+        buf_.prepare(n),
         [this, callback{std::move(callback)}](const asio::error_code& error, const std::size_t bytes_transferred) {
             if (error) {
                 LOG_MESSAGE_F(debug, "Async read ec: %s", error.message().c_str());

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -69,7 +69,7 @@ std::string net::ConnectionBase::MakeOutFilePath() const {
 
 // ======================================================================
 
-net::Connection::Connection(SocketT&& socket) : timer(socket.get_executor()), socket_(std::move(socket)) {
+net::Connection::Connection(SocketT&& socket) : socket_(std::move(socket)), timer_(socket_.get_executor()) {
     LOG_MESSAGE_F(
         info, "Created connection %llu, %s", id, this->socket_.remote_endpoint().address().to_string().c_str());
 }
@@ -156,6 +156,20 @@ void net::Connection::AsyncReceive(
 
             DecRefCount();
         });
+}
+
+void net::Connection::AsyncWait(std::function<void(const asio::error_code& error)>&& callback) {
+    IncRefCount();
+
+    timer_.async_wait([this, callback{std::move(callback)}](const asio::error_code& error) {
+        if (error) {
+            LOG_MESSAGE_F(debug, "Async wait ec: %s", error.message().c_str());
+        }
+
+        callback(error);
+
+        DecRefCount();
+    });
 }
 
 void net::Connection::IncRefCount() noexcept {

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -102,6 +102,8 @@ void net::Connection::AsyncWrite(
     const ByteVector& msg,
     std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback) {
 
+    IncRefCount();
+
     async_write(
         socket_,
         asio::buffer(msg),
@@ -112,11 +114,15 @@ void net::Connection::AsyncWrite(
             }
 
             callback(error, bytes_transferred);
+
+            DecRefCount();
         });
 }
 
 void net::Connection::AsyncRead(
     const std::size_t n, std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback) {
+
+    IncRefCount();
 
     async_read(
         socket_,
@@ -129,11 +135,15 @@ void net::Connection::AsyncRead(
             LOG_MESSAGE_F(debug, "Read %llu bytes", bytes_transferred);
 
             callback(error, bytes_transferred);
+
+            DecRefCount();
         });
 }
 
 void net::Connection::AsyncReceive(
     const std::size_t n, std::function<void(const asio::error_code& error, std::size_t bytes_transferred)>&& callback) {
+
+    IncRefCount();
 
     socket_.async_receive(
         buf.prepare(n),
@@ -143,6 +153,8 @@ void net::Connection::AsyncReceive(
             }
 
             callback(error, bytes_transferred);
+
+            DecRefCount();
         });
 }
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -37,7 +37,6 @@ std::ofstream& net::ConnectionBase::OpenOutFile() {
 }
 
 void net::ConnectionBase::FinishOutFile() {
-    assert(!outFilePath_.empty()); // BeginOutFiles was not called
     outFile_.close();
 }
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -173,9 +173,17 @@ void net::Connection::AsyncWait(std::function<void(const asio::error_code& error
 
 void net::Connection::IncRefCount() noexcept {
     refCount_++;
+
+    if (refCount_ == 1) {
+        LOG_MESSAGE_F(debug, "Connection %llu has first reference", id);
+    }
 }
 void net::Connection::DecRefCount() noexcept {
     assert(refCount_ != 0);
 
     refCount_--;
+
+    if (refCount_ == 0) {
+        LOG_MESSAGE_F(debug, "Connection %llu has zero references", id);
+    }
 }

--- a/src/net/service/connection_acceptor.cpp
+++ b/src/net/service/connection_acceptor.cpp
@@ -129,8 +129,8 @@ void net::ConnectionAcceptor::CallbackSentGreeting(Connection& conn) const noexc
 void net::ConnectionAcceptor::CallbackReceivedGreeting(Connection& conn,
                                                        const std::size_t bytes_transferred) const noexcept {
     try {
-        core::CapturingGuard<void()> guard([&]() { conn.buf.consume(bytes_transferred); });
-        const auto* bytes = asio::buffer_cast<const ByteVector::value_type*>(conn.buf.data());
+        core::CapturingGuard<void()> guard([&]() { conn.GetStreambuf().consume(bytes_transferred); });
+        const auto* bytes = asio::buffer_cast<const ByteVector::value_type*>(conn.GetStreambuf().data());
 
         conn.mediaProp = ParseClientGreeting(netData_->GetMediaConfig(), bytes, bytes_transferred);
 
@@ -138,7 +138,7 @@ void net::ConnectionAcceptor::CallbackReceivedGreeting(Connection& conn,
         conn.SetStatus(ConnectionStatus::active);
 
         try {
-            assert(conn.buf.size() == 0); // Buffer should be empty after finishing acceptance
+            assert(conn.GetStreambuf().size() == 0); // Buffer should be empty after finishing acceptance
 
             LOG_MESSAGE_F(info, "Accepted connection %llu", conn.id);
             onConnectionAccepted(conn);

--- a/src/net/service/connection_acceptor.cpp
+++ b/src/net/service/connection_acceptor.cpp
@@ -62,11 +62,7 @@ void net::ConnectionAcceptor::DoAsyncAccept() noexcept {
 }
 
 void net::ConnectionAcceptor::HandleAccept(asio::ip::tcp::socket& socket) const {
-    auto make_connection = [&]() -> Connection& {
-        core::GuardedAccess connections(netData_->connections);
-        return *connections->Add(std::move(socket));
-    };
-    auto& conn = make_connection(); // Heap allocated, exists after this method exits
+    auto& conn = *netData_->connections.Add(std::move(socket)); // Heap allocated, exists after this method exits
 
 
     // Send server greeting

--- a/src/net/service/connection_acceptor.cpp
+++ b/src/net/service/connection_acceptor.cpp
@@ -81,8 +81,8 @@ void net::ConnectionAcceptor::HandleAccept(asio::ip::tcp::socket& socket) const 
     });
 
     // Timeout
-    conn.timer.expires_after(netData_->GetNetProp().toSendServerGreeting);
-    conn.timer.async_wait([&](const asio::error_code& error) {
+    conn.SetTimerExpiresAfter(netData_->GetNetProp().toSendServerGreeting);
+    conn.AsyncWait([&](const asio::error_code& error) {
         if (error) {
             NET_LOG_F(error, "Send server greeting timeout ec: %s", error.message().c_str());
             return;
@@ -108,8 +108,8 @@ void net::ConnectionAcceptor::CallbackSentGreeting(Connection& conn) const noexc
                        });
 
         // Timeout
-        conn.timer.expires_after(netData_->GetNetProp().toReceiveClientGreeting);
-        conn.timer.async_wait([&](const asio::error_code& error) {
+        conn.SetTimerExpiresAfter(netData_->GetNetProp().toReceiveClientGreeting);
+        conn.AsyncWait([&](const asio::error_code& error) {
             if (error) {
                 NET_LOG_F(error, "Received client greeting timeout ec: %s", error.message().c_str());
                 return;

--- a/src/net/service/connection_gc.cpp
+++ b/src/net/service/connection_gc.cpp
@@ -29,8 +29,7 @@ void net::ConnectionGc::SetupSweepTimer() {
 void net::ConnectionGc::Sweep(NetData& net_data) {
     LOG_MESSAGE(debug, "Beginning connection gc pass");
 
-    core::GuardedAccess access(net_data.connections);
-    auto& connections = access->connections_;
+    auto& connections = net_data.connections.connections_;
 
     // Must use iterators as this will be erasing at it iterates
     for (auto it = connections.begin(); it != connections.end();) {

--- a/src/net/service/connection_gc.cpp
+++ b/src/net/service/connection_gc.cpp
@@ -2,6 +2,47 @@
 
 #include "net/service/connection_gc.h"
 
+#include <thread>
+
+#include "core/logger.h"
+#include "net/logger.h"
+#include "net/net_data.h"
+
 using namespace hyperion;
 
-void net::ConnectionGCService(NetData& net_data) {}
+void net::ConnectionGc::Start() {
+    SetupSweepTimer();
+}
+
+void net::ConnectionGc::SetupSweepTimer() {
+    timer_.expires_after(netData_.GetNetProp().sleepGcPass);
+    timer_.async_wait([&](const asio::error_code& error) {
+        if (error) {
+            NET_LOG_F(error, "GC timer ec: %s", error.message().c_str());
+            return;
+        }
+
+        Sweep(netData_);
+        SetupSweepTimer();
+    });
+}
+
+void net::ConnectionGc::Sweep(NetData& net_data) {
+    LOG_MESSAGE(debug, "Beginning connection gc pass");
+
+    core::GuardedAccess access(net_data.connections);
+    auto& connections = access->connections_;
+
+    // Must use iterators as this will be erasing at it iterates
+    for (auto it = connections.begin(); it != connections.end();) {
+        auto& conn = *it;
+
+        if (conn->CanDestruct()) {
+            LOG_MESSAGE_F(debug, "Sweeping connection %llu", conn->id);
+            it = connections.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+}

--- a/src/net/service/connection_gc.cpp
+++ b/src/net/service/connection_gc.cpp
@@ -19,7 +19,6 @@ void net::ConnectionGc::SetupSweepTimer() {
     timer_.async_wait([&](const asio::error_code& error) {
         if (error) {
             NET_LOG_F(error, "GC timer ec: %s", error.message().c_str());
-            return;
         }
 
         Sweep(netData_);

--- a/src/net/service/connection_listener.cpp
+++ b/src/net/service/connection_listener.cpp
@@ -14,38 +14,36 @@ using namespace hyperion;
 void DoAsyncReceive(net::Connection& conn) {
     assert(conn.buf.size() == 0);
 
-    conn.socket.async_receive( //
-        conn.buf.prepare(conn.buf.max_size()),
-        [&](const asio::error_code& error, const std::size_t bytes_transferred) {
-            core::CapturingGuard<void()> guard([&]() { conn.buf.consume(bytes_transferred); });
+    conn.AsyncReceive(conn.buf.max_size(), [&](const asio::error_code& error, const std::size_t bytes_transferred) {
+        core::CapturingGuard<void()> guard([&]() { conn.buf.consume(bytes_transferred); });
 
-            if (error) {
-                if (error.value() != asio::error::eof) {
-                    NET_LOG_F(error, "Connection listener async receive ec: %s", error.message().c_str());
-                }
-                conn.End();
-                return;
+        if (error) {
+            if (error.value() != asio::error::eof) {
+                NET_LOG_F(error, "Connection listener async receive ec: %s", error.message().c_str());
             }
+            conn.End();
+            return;
+        }
 
-            // This stream is unterminated
-            LOG_MESSAGE_F(debug, "%llu Received %llu bytes", conn.id, bytes_transferred);
+        // This stream is unterminated
+        LOG_MESSAGE_F(debug, "%llu Received %llu bytes", conn.id, bytes_transferred);
 
-            const auto* bytes = asio::buffer_cast<const net::ByteVector::value_type*>(conn.buf.data());
+        const auto* bytes = asio::buffer_cast<const net::ByteVector::value_type*>(conn.buf.data());
 
-            try {
-                auto& out_file = conn.OpenOutFile();
-                core::CapturingGuard<void()> of_guard([&]() { out_file.close(); });
+        try {
+            auto& out_file = conn.OpenOutFile();
+            core::CapturingGuard<void()> of_guard([&]() { out_file.close(); });
 
-                for (std::size_t i = 0; i < bytes_transferred; ++i) {
-                    out_file << bytes[i];
-                }
+            for (std::size_t i = 0; i < bytes_transferred; ++i) {
+                out_file << bytes[i];
             }
-            catch (std::exception& e) {
-                LOG_MESSAGE_F(error, "Failed to save received bytes to file: %s", e.what());
-            }
+        }
+        catch (std::exception& e) {
+            LOG_MESSAGE_F(error, "Failed to save received bytes to file: %s", e.what());
+        }
 
-            DoAsyncReceive(conn); // This needs to be at the END after done processing received bytes!!
-        });
+        DoAsyncReceive(conn); // This needs to be at the END after done processing received bytes!!
+    });
 }
 
 void net::BeginAsyncReceive(Connection& connection) {


### PR DESCRIPTION
## Added connection garbage collector
- All utilized async asio methods within net::Connection are wrapped by a reference counter
- Garbage collector sweeps connections after their reference becomes 0

## Bugfixes
- Fixed assertion failing if client is disconnected early from timeout
- Fixed MacOS CI runner failing on `brew update`
